### PR TITLE
BLDMGR-6439: Update Linux flavor name filter.

### DIFF
--- a/check_required_packages.sh
+++ b/check_required_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -uo pipefail
+set -euo pipefail
 
 function identify_platform() {
     platform="$(. /etc/os-release && echo "$ID")"
@@ -75,8 +75,7 @@ get_package_manager
 function get_missing_package() {
     missing_packages=()
     for package in ${required_packages[@]}; do
-        $cmd $package
-        if [[ $? != 0 ]]; then
+        if ! ($cmd $package); then
             missing_packages+=($package)
         fi
     done

--- a/check_required_packages.sh
+++ b/check_required_packages.sh
@@ -26,7 +26,8 @@ function get_required_packages() {
     *)
         echo "WARNING: List of dependencies for distribution \"$platform\" is unknown."
         echo "Please install libX11 and/or libfontconfig packages."
-        exit
+        echo "List of supported platforms can be found at: https://www.schrodinger.com/supportedplatforms"
+        exit 1
         ;;
     esac
 }


### PR DESCRIPTION
Updated strings to check for Suse platforms to specific editions (sled/ sles) and Redhat to rhel.

Also having `set -e` turned out to be problematic. We actually want the script to proceed if there is non 0 exit code when it checks for package.
```
[buildbot@pdx-rheld7-lv01 ~]$ rpm -q xcb-util-renderutil
package xcb-util-renderutil is not installed
[buildbot@pdx-rheld7-lv01 ~]$ echo $?
1
```
For platform we don't have required packages list yet, print out general required package message and exit. 
 