### PR TITLE
INST-2148: Check if package installed offline.

### DIFF
--- a/check_required_packages.sh
+++ b/check_required_packages.sh
@@ -39,10 +39,7 @@ function check_if_package_installed() {
     "ubuntu")
         cmd="dpkg -s"
         ;;
-    "centos")
-        cmd="yum list"
-        ;;
-    "rhel" | "rocky" | "sled" | "sles")
+    "centos" | "rhel" | "rocky" | "sled" | "sles")
         cmd="rpm -q"
         ;;
     *)


### PR DESCRIPTION
Use 'rpm -q' instead of 'yum list' to check if package installed on centos machines for the command to work offline when package isn't installed.

Seems like `rpm -q` and `dpkg -s` work fine offline and `rpm` is available on centos by default. This is just from reading, not tested on an offline machine.