### PR TITLE
Add LF to report pacakges + fixed package requirements for centos/rhel/ubuntu

### DIFF
--- a/check_required_packages.sh
+++ b/check_required_packages.sh
@@ -97,6 +97,6 @@ function get_missing_package() {
     fi
 }
 
-echo "required_packages for your platform are: ${required_packages[@]}"
+echo -e "required_packages for your platform are: \n${required_packages[@]}"
 
 get_missing_package

--- a/packages/centos/2023-2/packages.txt
+++ b/packages/centos/2023-2/packages.txt
@@ -25,8 +25,6 @@ mesa-libGLU
 mesa-libglapi
 ncurses-libs
 nss-softokn-freebl
-nvidia-driver-NVML
-nvidia-driver-cuda-libs
 openssl-libs
 pcre
 xcb-util

--- a/packages/rhel/2023-2/packages.txt
+++ b/packages/rhel/2023-2/packages.txt
@@ -25,3 +25,4 @@ pcre
 xcb-util
 xcb-util-image
 xcb-util-keysyms
+xcb-util-renderutil

--- a/packages/ubuntu/2023-2/packages.txt
+++ b/packages/ubuntu/2023-2/packages.txt
@@ -21,6 +21,7 @@ libxcb-shm0
 libxcb-sync1
 libxcb-util1
 libxcb-xfixes0
+libxcb-xinput0
 libxcb-xkb1
 libxcb1
 libxdmcp6


### PR DESCRIPTION
- Added a LF while reporting required packages ( From Dan's suggestion to BLDMGR-6435)

- For centos, skipped nvidia* package requirement coming from desmond. As mentioned in BLDMGR-6435, these library requirements look legitimate to me. But we don't seem to be forcing it. So skipped this for now for 23-2, and will file a case to bring in for 23-3.

Below was missed where https://opengrok.schrodinger.com/xref/mmshare/python/scripts/test/test_canonical_packages.py?r=550b3b41#218 was skipping shared library requirement when ldd deps report 'not found', and skipped when running in distros of different machine. 

- Running in pdx-rheld7-lv01.schrodinger.com vs pdx-rhel8-lv01 where rheld7 was missing 'xcb-util-renderutil ' package. 
-  Running in ubuntu1804 vs ubuntu2004 where ubuntu1804 was missing 'libxcb-xinput0'  

I will file a ticket for 23-3 to fix test_canonical_packages to be strict looking at 'not found' and report. For 23-2 above should be okay for good start.

