### PR TITLE
Allow libnsl as package requirement as recommended in 'Linux requirements' page

### DIFF
--- a/packages/rhel/2023-2/packages.txt
+++ b/packages/rhel/2023-2/packages.txt
@@ -14,6 +14,7 @@ libXt
 libdrm
 libibverbs
 libnl3
+libnsl
 libuuid
 libxcb
 libxkbcommon

--- a/packages/rhel/2023-3/packages.txt
+++ b/packages/rhel/2023-3/packages.txt
@@ -14,6 +14,7 @@ libXt
 libdrm
 libibverbs
 libnl3
+libnsl
 libuuid
 libxcb
 libxkbcommon


### PR DESCRIPTION
This package is required and should not be skipped ( https://reviewboard.schrodinger.com/r/79073) as we document in https://www.schrodinger.com/sites/default/files/s3/release/current/Documentation/html/install_guide/software_requirements_linux.htm 

I initially skipped since pdx-rheld7-lv01 didn't have this package, and pdx-rhel8-lv02 has it. I will append to https://freshservice.schrodinger.com/support/tickets/6813 to get the package installed in rheld7.

