### PR TITLE
Add xcb-util-cursor or libxcb-cursor0 as new requirement for Qt 6.5.5…

### DIFF
--- a/packages/rhel/2024-3/packages.txt
+++ b/packages/rhel/2024-3/packages.txt
@@ -25,6 +25,7 @@ mesa-libglapi
 nfs-utils
 pcre
 xcb-util
+xcb-util-cursor
 xcb-util-image
 xcb-util-keysyms
 xcb-util-renderutil

--- a/packages/rocky/2024-3/packages.txt
+++ b/packages/rocky/2024-3/packages.txt
@@ -28,6 +28,7 @@ nfs-utils
 pcre
 pcre2
 xcb-util
+xcb-util-cursor
 xcb-util-image
 xcb-util-keysyms
 xcb-util-renderutil

--- a/packages/ubuntu/2024-3/packages.txt
+++ b/packages/ubuntu/2024-3/packages.txt
@@ -9,6 +9,7 @@ libsm6
 libx11-6
 libx11-xcb1
 libxau6
+libxcb-cursor0
 libxcb-glx0
 libxcb-icccm4
 libxcb-image0


### PR DESCRIPTION
Add a new requirement for Qt 6.5.5  ( BLDMGR-8370 )