### PR TITLE
BLDMGR-8638: Update testInstallationDependencies for 2024-4

### DIFF
--- a/packages/ubuntu/2024-4/packages.txt
+++ b/packages/ubuntu/2024-4/packages.txt
@@ -21,7 +21,6 @@ libxcb-shm0
 libxcb-sync1
 libxcb-util1
 libxcb-xfixes0
-libxcb-xinput0
 libxcb-xkb1
 libxcb1
 libxdmcp6


### PR DESCRIPTION
### Description
 Removed `libxcb-xinput0` from Ubuntu package requirements for 2024-4.