### PR TITLE
Removed default core packages identified by GHA STU run of ubuntu

### DIFF
--- a/packages/ubuntu/2025-3/packages.txt
+++ b/packages/ubuntu/2025-3/packages.txt
@@ -3,7 +3,6 @@ libfontconfig1
 libfreetype6
 libglu1-mesa
 libice6
-libpng16-16
 libsm6
 libx11-6
 libx11-xcb1
@@ -31,5 +30,4 @@ libxkbcommon-x11-0
 libxkbcommon0
 libxrender1
 libxss1
-libxt6
 mesa-utils


### PR DESCRIPTION
Both these packages are part of core system, and doesn't need to be listed in the requirements. The GHA run has alerted this way -

```
packages to remove from canonical list - {'libxt6', 'libpng16-16'}
```