### PR TITLE
Remove packages available as part of core rocky

### DIFF
--- a/packages/rocky/2025-3/packages.txt
+++ b/packages/rocky/2025-3/packages.txt
@@ -14,8 +14,6 @@ libXi
 libXrender
 libXt
 libdrm
-libibverbs
-libnl3
 libnsl
 libpng
 libuuid

--- a/packages/ubuntu/2025-3/packages.txt
+++ b/packages/ubuntu/2025-3/packages.txt
@@ -3,7 +3,6 @@ libfontconfig1
 libfreetype6
 libglu1-mesa
 libice6
-libpng16-16
 libsm6
 libx11-6
 libx11-xcb1
@@ -31,5 +30,4 @@ libxkbcommon-x11-0
 libxkbcommon0
 libxrender1
 libxss1
-libxt6
 mesa-utils


### PR DESCRIPTION
The removed packages doesn't need to be listed as part of canonical requirements. This is to fix the alert raised in the periodic run - https://github.com/schrodinger/core-suite-stu/actions/runs/15777375970/job/44474783279#step:9:118