### PR TITLE
Remove freetype/png as requirement for 25-4 

### DIFF
--- a/packages/rhel/2025-4/packages.txt
+++ b/packages/rhel/2025-4/packages.txt
@@ -1,6 +1,5 @@
 expat
 fontconfig
-freetype
 glx-utils
 libICE
 libSM

--- a/packages/rocky/2025-4/packages.txt
+++ b/packages/rocky/2025-4/packages.txt
@@ -1,6 +1,5 @@
 expat
 fontconfig
-freetype
 glx-utils
 libICE
 libSM
@@ -15,7 +14,6 @@ libXrender
 libXt
 libdrm
 libnsl
-libpng
 libuuid
 libxcb
 libxkbcommon

--- a/packages/ubuntu/2025-4/packages.txt
+++ b/packages/ubuntu/2025-4/packages.txt
@@ -1,6 +1,5 @@
 libdrm2
 libfontconfig1
-libfreetype6
 libglu1-mesa
 libice6
 libsm6


### PR DESCRIPTION
Removed the freetype/png packages being listed as required ones as we now bundle in suite from rock8 for harfbuzz package. Also these packages are available in the core distro, so they don't need to be listed.