### PR TITLE
Include CUPS for Qt 6.5.12 printsupport plugin BLDMGR-11761

### DIFF
--- a/packages/opensuse-leap/2026-3/packages.txt
+++ b/packages/opensuse-leap/2026-3/packages.txt
@@ -11,6 +11,7 @@ libXi6
 libXrender1
 libXss1
 libXt6
+libcups2
 libdrm2
 libexpat1
 libfontconfig1

--- a/packages/rhel/2026-3/packages.txt
+++ b/packages/rhel/2026-3/packages.txt
@@ -1,3 +1,4 @@
+cups-libs
 expat
 fontconfig
 glx-utils

--- a/packages/rocky/2026-3/packages.txt
+++ b/packages/rocky/2026-3/packages.txt
@@ -1,3 +1,4 @@
+cups-libs
 expat
 fontconfig
 glx-utils

--- a/packages/ubuntu/2026-3/packages.txt
+++ b/packages/ubuntu/2026-3/packages.txt
@@ -1,3 +1,4 @@
+libcups2
 libdrm2
 libfontconfig1
 libglu1-mesa

--- a/packages/ubuntu24/2026-3/packages.txt
+++ b/packages/ubuntu24/2026-3/packages.txt
@@ -1,3 +1,4 @@
+libcups2t64
 libdrm2
 libfontconfig1
 libglu1-mesa


### PR DESCRIPTION
Added the requirement for supported distros to accomodate the plugin added for Qt 6.5.12

Tested using core-stu-containers adding this requirement and make sure the plugin deps is resolved -

```
**rocky8**
[rajagopa@desk-lu554 ~]$ $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup        libcups.so.2 => /lib64/libcups.so.2 (0x00007eff49539000)
**rocky9**
[rajagopa@desk-lu554 ~]$ $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup        libcups.so.2 => /lib64/libcups.so.2 (0x00007fe3f55d4000)
**rocky10**
[rajagopa@desk-lu554 ~]$ $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup        libcups.so.2 => /lib64/libcups.so.2 (0x00007f1438a99000)
**ubuntu2204**
rajagopa@desk-lu554:~$  $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup
        libcups.so.2 => /lib/x86_64-linux-gnu/libcups.so.2 (0x00007faccb2bc000)
**ubuntu2404**
rajagopa@desk-lu554:~$  $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup
        libcups.so.2 => /lib/x86_64-linux-gnu/libcups.so.2 (0x00007f5f9c522000)
**opensuse**
rajagopa@desk-lu554:~>  $SCHRODINGER/run ldd /scr/rajagopa/builds/2026-3/mmshare-v7.5/lib/Linux-x86_64/qt_plugins/printsupport/libcupsprintersupport.so  | grep cup
        libcups.so.2 => /usr/lib64/libcups.so.2 (0x00007fc2e4b05000)
```