### PR TITLE
Add package requirement for libcrypt auth package for supported linux distros in 26-3 and above BLDMGR-11853

### DIFF
--- a/packages/opensuse-leap/2026-3/packages.txt
+++ b/packages/opensuse-leap/2026-3/packages.txt
@@ -12,6 +12,7 @@ libXrender1
 libXss1
 libXt6
 libcups2
+libcrypt1
 libdrm2
 libexpat1
 libfontconfig1

--- a/packages/rocky10/2026-1/packages.txt
+++ b/packages/rocky10/2026-1/packages.txt
@@ -1,4 +1,3 @@
-cups-libs
 expat
 fontconfig
 glx-utils
@@ -15,7 +14,6 @@ libXrender
 libXt
 libdrm
 libuuid
-libxcrypt
 libxcb
 libxkbcommon
 libxkbcommon-x11

--- a/packages/rocky10/2026-2/packages.txt
+++ b/packages/rocky10/2026-2/packages.txt
@@ -1,4 +1,3 @@
-cups-libs
 expat
 fontconfig
 glx-utils
@@ -15,7 +14,6 @@ libXrender
 libXt
 libdrm
 libuuid
-libxcrypt
 libxcb
 libxkbcommon
 libxkbcommon-x11

--- a/packages/rocky10/2026-3/packages.txt
+++ b/packages/rocky10/2026-3/packages.txt
@@ -15,7 +15,7 @@ libXrender
 libXt
 libdrm
 libuuid
-libxcrypt
+libxcrypt-compat
 libxcb
 libxkbcommon
 libxkbcommon-x11

--- a/packages/ubuntu/2026-3/packages.txt
+++ b/packages/ubuntu/2026-3/packages.txt
@@ -1,4 +1,5 @@
 libcups2
+libcrypt1
 libdrm2
 libfontconfig1
 libglu1-mesa

--- a/packages/ubuntu24/2026-3/packages.txt
+++ b/packages/ubuntu24/2026-3/packages.txt
@@ -1,4 +1,5 @@
 libcups2t64
+libcrypt1
 libdrm2
 libfontconfig1
 libglu1-mesa


### PR DESCRIPTION
This is a platform specific package, and cannot be considered to include from rocky8 base build for supported linux distros. The policy to include from base builder machine is set here - https://opengrok.schrodinger.com/xref/mmshare/build_tools/global_macros.py?r=3dd5f09e#1690

Any extra dependency especially auth is not good to consider from builder machine.

I separated rocky10 for the package `libxcrypt-compat` thats needs to be differentiated from rocky's `libxcrypt` similar to ubuntu24, and considered release 26-1 to 26-3 as we started supported rocky 10 from 26-1.

This will address JOBCON-9897 to remove the workaround to address issues bundling this library in our suite.